### PR TITLE
Fixed issue-54

### DIFF
--- a/web-extension/extractHtml.js
+++ b/web-extension/extractHtml.js
@@ -12,7 +12,7 @@ var allowedTags = [
     'address', 'article', 'aside', 'footer', 'header', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'hgroup', 'nav', 'section', 'dd', 'div', 'dl', 'dt', 'figcaption', 'figure', 'hr', 'li',
     'main', 'ol', 'p', 'pre', 'ul', 'a', 'abbr', 'b', 'bdi', 'bdo', 'br', 'cite', 'code', 'data',
-    'dfn', 'em', 'i', 'img', 'kbd', 'mark', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'small', 'span',
+    'dfn', 'em', 'i', 'img', 'kbd', 'mark', 'q', 'rb', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'small', 'span',
     'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr', 'del', 'ins', 'caption', 'col', 'colgroup',
     'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr',
     'math', 'maction', 'menclose', 'merror', 'mfenced', 'mfrac', 'mglyph', 'mi', 'mlabeledtr', 'mmultiscripts', 'mn', 'mo', 'mover', 'mpadded', 'mphantom', 'mroot',


### PR DESCRIPTION
Implemented a "Japanese" checkbox in the menu that does the following:
Changes the page progression at spine level
Inserts a static japanese.css file implementing the most basic level of css for Japanese ebooks (from http://www2.infocity.co.jp/epubjp/EPUB3_Japanese_Basic_Standard_E_1020.pdf) and includes it in all appropriate places.

The approach may be sub-optimal, but I couldn't figure out why cssjson was making such a mess of custom stylesheets.